### PR TITLE
Added example to Unsupported phi use of const or let variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,14 +383,41 @@ function test() {
   }
   const self = this; // `this` should both be present for this to happen
 }
+
+function test2(arr) { // selection sort
+  let curr = 0;
+  let n = arr.length;
+  while (curr < n) {
+    let low = curr;
+    let next = curr + 1;
+    while (next < n) {
+      if (arr[next] > arr[low]) {
+        low = next;
+      }
+      next++;
+    }
+    let tmp = arr[curr]; // this is the line that triggers the bug
+    arr[curr] = arr[low];
+    arr[low] = tmp;
+    curr++;
+  }
+};
+
+test2([...Array(1000).keys()]);
 ```
 
 * Why
   * Crankshaft sees a hole (marker for Temporary Dead Zone of `let`/`const`) and aborts compilation.
 
 * Advices
+  * In test2, the error can be suppressed in the following ways:
+    * Change tmp declaration from `let` to `var`.
+    * Declare `tmp` at the beginning of the function, before the outer while loop.
+    * Encapsulate the last 4 lines of the function into an arbitrary block.
+    * Remove the inner while loop.
 
 * External examples
+  * https://gist.github.com/billhance/b576db4a58b2c3ccbe67df07acf4cc1f
 
 
 ### Yield


### PR DESCRIPTION
I came across the "Unsupported phi use of const or let variable" bug while learning es6 and practicing a selection sort. I noticed my implementation was way slower than I expected so this might be a misunderstanding of some block scope gotcha in JS on my part. 

Here is a fiddle that demonstrating the bug: https://jsfiddle.net/billhance/wfz9fcs6/1/

In console profiler, I saw an increase of 800% where input n = 1000 when this bug was present.

![image](https://cloud.githubusercontent.com/assets/476902/21066359/0544f9a6-be1a-11e6-9297-0c460d82d692.png)

![image](https://cloud.githubusercontent.com/assets/476902/21066380/19134eec-be1a-11e6-8c4f-1333d24c44b4.png)

![image](https://cloud.githubusercontent.com/assets/476902/21066600/3e3ba34e-be1b-11e6-988f-78e922104770.png)
