### PR TITLE
Fix a possible typo in code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ function key() {
 }
 function test2() {
   var obj = {};
-  for(key() in obj);
+  for(key in obj);
 }
 ```
 


### PR DESCRIPTION
Currently, the code throws (with non-empty `obj` and `test2()` call): `ReferenceError: Invalid left-hand side in for-loop`.